### PR TITLE
fix unsafe loading of yaml

### DIFF
--- a/norns/cfg.py
+++ b/norns/cfg.py
@@ -1,6 +1,6 @@
 import os
 from appdirs import user_config_dir
-from yaml import load, dump
+from yaml import full_load, dump
 try:
     from UserDict import DictMixin
 except ImportError:
@@ -69,7 +69,7 @@ class Config(DictMixin):
             path to config file
         """
         with open(path) as f:
-            self.config = load(f)
+            self.config = full_load(f)
 
     def save(self):
         """ 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nose
 appdirs
-pyyaml
+pyyaml>=5.1


### PR DESCRIPTION
see: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Now makes use of **yaml.full_load()**, the current default loader of yaml