### PR TITLE
updated yaml.load(input)

### DIFF
--- a/norns/cfg.py
+++ b/norns/cfg.py
@@ -69,7 +69,7 @@ class Config(DictMixin):
             path to config file
         """
         with open(path) as f:
-            self.config = load(f)
+            self.config = load(f, Loader=yaml.FullLoader)
 
     def save(self):
         """ 


### PR DESCRIPTION
The function without 'Loader=' argument is deprecated due to safety issues. By setting ', Loader=yaml.FullLoader', the function operates as before. The safety issue remains unchanged, as detailed here: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation