### PR TITLE
added string representation

### DIFF
--- a/norns/cfg.py
+++ b/norns/cfg.py
@@ -94,5 +94,8 @@ class Config(DictMixin):
     def __iter__(self):
         return self.config.__iter__()
     
+    def __str__(self):
+        return '{' + ', '.join(': '.join([str(key), str(value)]) for key, value in self.items()) + '}'
+
     def keys(self):
         return self.config.keys()


### PR DESCRIPTION
`print(norns.config(config_file="tests/data/simple.yaml")`

previously:
`<norns.cfg.Config object at 0x7fc0b7be7f28>`
now:
`{path: /home/simon, integer: 10, text: In one Age, called the third age by some...}`
