### PR TITLE
fix weak warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,49 @@
 # norns
 
+[![bioconda-badge](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io)
+[![PyPI version](https://badge.fury.io/py/norns.svg)](https://badge.fury.io/py/norns)
+
 Simple yaml-based config module.
 
 ## Installation
 
-Via pip, for now.
+Via conda:
+
+```
+$ conda install norns
+```
+
+or via pip:
 
 ```
 $ pip install norns
 ```
 
 ## Usage
+Create a config file in the user condig directory
+```
+import norns
 
+# yaml template
+dflt = "/path/to/default.yaml"
+config = norns.config("filename", default=dflt)
+```
 
-## Todo
+Read and update a config file
+```
+# read
+config.keys()
 
-* Add todo!
+>>> dict_keys(['phone_numbers', 'launch_codes', 'birthdays'])
+
+# alter
+launch_codes = config.get("launch_codes", [])
+launch_codes.append(1234)
+
+# update
+config["launch_codes"] = launch_codes
+config.save()
+```
 
 ## Contributing
 

--- a/norns/__about__.py
+++ b/norns/__about__.py
@@ -1,3 +1,3 @@
 """Metadata"""
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 __author__ = "Simon van Heeringen"

--- a/norns/__init__.py
+++ b/norns/__init__.py
@@ -1,4 +1,7 @@
 import norns.cfg
 
+from norns.exceptions import ConfigError
+
+
 def config(name=None, config_file=None, default=None):
     return norns.cfg.Config(name=name, config_file=config_file, default=default)

--- a/norns/cfg.py
+++ b/norns/cfg.py
@@ -2,6 +2,7 @@ import os
 import sys
 from appdirs import user_config_dir
 from yaml import full_load, dump
+
 try:
     from UserDict import DictMixin
 except ImportError:
@@ -10,20 +11,22 @@ import pkg_resources
 
 from norns.exceptions import ConfigError
 
-class Config(DictMixin):
-    """ Configuration class. 
 
-    State will be shared across config objects. 
+class Config(DictMixin):
+    """ Configuration class.
+
+    State will be shared across config objects.
     """
+
     # Store shared state, Borg pattern
     __shared_state = {}
-    
+
     def __init__(self, name=None, config_file=None, default=None):
-        """ 
+        """
         Create a Config object and read a config file.
 
         Either name or config_file is required.
-        
+
         Parameters
         ----------
         name : str, optional
@@ -31,35 +34,34 @@ class Config(DictMixin):
 
         config_file : str, optional
             name of specific configration file
-        
+
         default : str, optional
             default config, relative to package directory
         """
 
         self.__dict__ = self.__shared_state
-        
+
         self.config_file = None
 
         # Lookup the config file according to XDG hierarchy
         if name:
             self.config_file = os.path.join(
-                    user_config_dir(name), "{}.yaml".format(name)
-                )
-        elif config_file: # Read specific file
+                user_config_dir(name), "{}.yaml".format(name)
+            )
+        elif config_file:  # Read specific file
             self.config_file = config_file
-        
-        if default and (not self.config_file or 
-                not os.path.exists(self.config_file)):
+
+        if default and (not self.config_file or not os.path.exists(self.config_file)):
             self.config_file = pkg_resources.resource_filename(name, default)
-        
+
         if not self.config_file or not os.path.exists(self.config_file):
             raise ConfigError("please provide name or config_file")
-        
+
         self.config = {}
         self.load(self.config_file)
 
     def load(self, path):
-        """ 
+        """
         Load yaml-formatted config file.
 
         Parameters
@@ -74,7 +76,7 @@ class Config(DictMixin):
                 self.config = {}
 
     def save(self):
-        """ 
+        """
         Save current state of config dictionary.
         """
         with open(self.config_file, "w") as f:
@@ -82,10 +84,10 @@ class Config(DictMixin):
 
     def __getitem__(self, key):
         return self.config.__getitem__(key)
-       
+
     def __delitem__(self, key):
         self.config.__delitem__(key)
-    
+
     def __setitem__(self, key, value):
         return self.config.__setitem__(key, value)
 
@@ -94,6 +96,6 @@ class Config(DictMixin):
 
     def __iter__(self):
         return self.config.__iter__()
-    
+
     def keys(self):
         return self.config.keys()

--- a/tests/norns_test.py
+++ b/tests/norns_test.py
@@ -2,11 +2,14 @@ from nose.tools import *
 import norns
 from norns.exceptions import ConfigError
 
+
 def setup():
     print("SETUP!")
 
+
 def teardown():
     print("TEAR DOWN!")
+
 
 def test_basic():
     cfg = norns.config(config_file="tests/data/simple.yaml")
@@ -14,7 +17,7 @@ def test_basic():
     assert cfg["path"] == "/home/simon"
     assert 3 == len(cfg.keys())
 
+
 @raises(ConfigError)
 def test_no_arguments():
     cfg = norns.config()
-


### PR DESCRIPTION
Pycharm was giving me warnings that norns doesn't properly export ConfigError via __init__. So I did a small pass :)
- added `from norns.exceptions import ConfigError` to init
- polished README
- black formatting
- bumped hotfix version number

P.S. I found the WoT easter egg!