### PR TITLE
Support Python 3.13

### DIFF
--- a/norns/__about__.py
+++ b/norns/__about__.py
@@ -1,3 +1,3 @@
 """Metadata"""
-__version__ = '0.1.4'
+__version__ = '0.1.6'
 __author__ = "Simon van Heeringen"

--- a/norns/cfg.py
+++ b/norns/cfg.py
@@ -5,7 +5,7 @@ try:
     from UserDict import DictMixin
 except ImportError:
     from collections.abc import MutableMapping as DictMixin
-import pkg_resources
+import importlib.resources
 
 from norns.exceptions import ConfigError
 
@@ -49,8 +49,9 @@ class Config(DictMixin):
         
         if default and (not self.config_file or 
                 not os.path.exists(self.config_file)):
-            self.config_file = pkg_resources.resource_filename(name, default)
-        
+            self.config_file = importlib.resources.files(name) /  default
+            #self.config_file = importlib.resources.as_file(config_traversable) 
+       
         if not self.config_file or not os.path.exists(self.config_file):
             raise ConfigError("please provide name or config_file")
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nose
+pynose
 appdirs
 pyyaml>=5.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ package_data = {
 }
 
 requires = [
-    'nose',
+    'pynose',
     'appdirs',
     'pyyaml',
 ]


### PR DESCRIPTION
Fixes #9
- **use modern importlib.resources**
- **bump version**
- **use pynose as nose is not maintained**